### PR TITLE
Explicit require active_support prior to active_support/core_ext

### DIFF
--- a/lib/bluepill.rb
+++ b/lib/bluepill.rb
@@ -9,6 +9,7 @@ require 'syslog'
 require 'timeout'
 require 'logger'
 
+require 'active_support'
 require 'active_support/inflector'
 require 'active_support/core_ext/hash'
 require 'active_support/core_ext/numeric'


### PR DESCRIPTION
Context
==

Bluepill returns an error as below once in a while when we tried to restart,

```
/usr/local/lib/ruby/gems/2.4.0/gems/activesupport-5.2.2/lib/active_support/number_helper.rb:5:in `<module:NumberHelper>': uninitialized constant ActiveSupport::Autoload (NameError)
	from /usr/local/lib/ruby/gems/2.4.0/gems/activesupport-5.2.2/lib/active_support/number_helper.rb:4:in `<module:ActiveSupport>'
```

It works for most of our systems, but a few wasnt working, and turned out,
there is an importance of order of how to load `active_support/core_ext`.

As per here, https://github.com/rails/rails/issues/14664,

Explicit require of `active_support` would help to be certain the right libraries are loaded
prior to `active_support/core_ext`.